### PR TITLE
Pivot statusline to Artemis III pre-launch countdown

### DIFF
--- a/src/statusline.ts
+++ b/src/statusline.ts
@@ -1,8 +1,18 @@
-import { type ArtemisPosition, type MissionPhase, C, LAUNCH_TIME } from "./types.ts";
-import { formatDistance, formatMET } from "./api.ts";
-import { renderTrajectoryBar } from "./trajectory.ts";
+import {
+  type ArtemisPosition,
+  type MissionPhase,
+  C,
+  ARTEMIS_III_LAUNCH_TARGET,
+} from "./types.ts";
 
 const PHASE_LABELS: Record<MissionPhase, string> = {
+  // Pre-launch (Artemis III ground processing)
+  pre_launch: "pre-launch",
+  ground_processing: "ground ops",
+  rollout: "rollout",
+  wet_dress_rehearsal: "WDR",
+  final_countdown: "T-0",
+  // In-flight (retained for future missions)
   earth_orbit: "orbit",
   transit_to_moon: "transit",
   lunar_flyby: "flyby",
@@ -11,72 +21,73 @@ const PHASE_LABELS: Record<MissionPhase, string> = {
   complete: "splashdown",
 };
 
-// Mission milestones from JPL Horizons (exact times relative to launch)
-// Launch: 2026-04-01 22:35:12 UTC
-const MILESTONES = [
-  { name: "solar array deploy", hoursFromLaunch: 0.33 },
-  { name: "perigee raise burn", hoursFromLaunch: 0.83 },
-  { name: "apogee raise burn", hoursFromLaunch: 1.8 },
-  { name: "ICPS separation", hoursFromLaunch: 3.4 },
-  { name: "upper stage sep burn", hoursFromLaunch: 4.83 },
-  { name: "perigee raise burn", hoursFromLaunch: 13.48 },
-  { name: "TLI burn 🔥", hoursFromLaunch: 25.13 },
-  { name: "trajectory correction #1", hoursFromLaunch: 48.13 },
-  { name: "trajectory correction #2", hoursFromLaunch: 73.13 },
-  { name: "trajectory correction #3", hoursFromLaunch: 100.48 },
-  { name: "lunar sphere entry", hoursFromLaunch: 102.13 },
-  { name: "closest lunar approach 🌑", hoursFromLaunch: 120.52 },
-  { name: "lunar sphere exit", hoursFromLaunch: 138.87 },
-  { name: "return correction #1", hoursFromLaunch: 145.48 },
-  { name: "manual piloting demo 🎮", hoursFromLaunch: 172.33 },
-  { name: "return correction #2", hoursFromLaunch: 196.48 },
-  { name: "return correction #3", hoursFromLaunch: 212.48 },
-  { name: "CM/SM separation", hoursFromLaunch: 217.15 },
-  { name: "entry interface Mach 32 🔥", hoursFromLaunch: 217.48 },
-  { name: "drogue chute deploy", hoursFromLaunch: 217.65 },
-  { name: "main chutes deploy 🪂", hoursFromLaunch: 217.68 },
-  { name: "SPLASHDOWN 🌊", hoursFromLaunch: 217.7 },
-];
-
-
-function getNextMilestone(missionElapsedMs: number): string {
-  const hoursElapsed = missionElapsedMs / 3_600_000;
-  for (const m of MILESTONES) {
-    if (m.hoursFromLaunch > hoursElapsed) {
-      const hoursUntil = m.hoursFromLaunch - hoursElapsed;
-      if (hoursUntil < 1 / 60) {
-        const secs = Math.round(hoursUntil * 3600);
-        return `${m.name} in ${secs}s`;
-      }
-      if (hoursUntil < 1) {
-        const mins = Math.round(hoursUntil * 60);
-        return `${m.name} in ${mins}m`;
-      }
-      if (hoursUntil < 24) {
-        const h = Math.floor(hoursUntil);
-        const mins = Math.round((hoursUntil - h) * 60);
-        return `${m.name} in ${h}h${mins > 0 ? ` ${mins}m` : ""}`;
-      }
-      const days = Math.floor(hoursUntil / 24);
-      const h = Math.round(hoursUntil % 24);
-      return `${m.name} in ${days}d ${h}h`;
-    }
-  }
-  return "mission complete 🎉";
+// Artemis III pre-launch milestones.
+// All dates are TENTATIVE — NASA has not announced a hard L-0 schedule.
+// Times are absolute UTC instants so we don't have to track "days from now"
+// (which would shift on every render). Update these as NASA publishes the
+// real ground-processing timeline.
+interface Milestone {
+  name: string;
+  at: Date;
 }
 
-export function renderStatusline(pos: ArtemisPosition): string {
-  // Show sub-km precision when interpolating — makes the counter tick visibly
-  const dist = pos.distanceEarthKm >= 1000
-    ? formatDistance(pos.distanceEarthKm)
-    : pos.distanceEarthKm.toFixed(1);
-  const vel = pos.velocityKmS.toFixed(2);
-  const met = formatMET(pos.missionElapsedMs);
-  const phase = PHASE_LABELS[pos.phase] ?? pos.phase;
-  const stale = pos.stale ? `${C.dim} ~${C.reset}` : "";
-  const next = getNextMilestone(pos.missionElapsedMs);
-  const trajectory = renderTrajectoryBar(pos);
+const MILESTONES: Milestone[] = [
+  { name: "Artemis II: mission complete \u2713", at: new Date("2026-04-10T17:07:00-07:00") },
+  { name: "SLS stacking review",                at: new Date("2026-11-15T00:00:00Z") },
+  { name: "Orion + SLS mate",                   at: new Date("2027-02-15T00:00:00Z") },
+  { name: "SLS rollout to pad 39B",             at: new Date("2027-08-01T00:00:00Z") },
+  { name: "wet dress rehearsal",                at: new Date("2027-08-15T00:00:00Z") },
+  { name: "flight readiness review",            at: new Date("2027-08-25T00:00:00Z") },
+  { name: "L-24h: launch countdown starts",     at: new Date("2027-08-31T00:00:00Z") },
+  { name: "T-0: LIFTOFF \uD83D\uDE80",          at: ARTEMIS_III_LAUNCH_TARGET },
+  // Post-launch — Artemis III is a LEO/HEO rendezvous demo, NOT a lunar landing.
+  { name: "Orion / HLS rendezvous demo",        at: new Date(ARTEMIS_III_LAUNCH_TARGET.getTime() + 1 * 86_400_000) },
+];
 
-  const src = pos.source ? ` ${C.dim}${pos.source}${C.reset}` : "";
-  return `${C.gold}🚀 ${dist}km${C.reset} ${C.cyan}${vel}km/s${C.reset} ${C.gray}MET ${met}${C.reset} ${C.green}${phase}${C.reset} ${C.yellow}▸${next}${C.reset}${stale}${src} ${trajectory}`;
+function formatRemaining(ms: number): string {
+  // Always positive; caller decides T- vs L+ prefix
+  const abs = Math.max(0, ms);
+  const totalMin = Math.floor(abs / 60_000);
+  const totalHrs = Math.floor(totalMin / 60);
+  const days = Math.floor(totalHrs / 24);
+  const hours = totalHrs % 24;
+  const mins = totalMin % 60;
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${mins}m`;
+  if (mins > 0) return `${mins}m`;
+  const secs = Math.max(0, Math.floor(abs / 1000));
+  return `${secs}s`;
+}
+
+function getNextMilestone(now: Date): string {
+  const t = now.getTime();
+  for (const m of MILESTONES) {
+    if (m.at.getTime() > t) {
+      return `${m.name} in ${formatRemaining(m.at.getTime() - t)}`;
+    }
+  }
+  return "Artemis III flight in progress";
+}
+
+// Pre-launch T-minus / post-launch L+ countdown relative to ARTEMIS_III_LAUNCH_TARGET
+function formatCountdown(now: Date): string {
+  const deltaMs = ARTEMIS_III_LAUNCH_TARGET.getTime() - now.getTime();
+  if (deltaMs > 0) return `T-${formatRemaining(deltaMs)}`;
+  return `L+${formatRemaining(-deltaMs)}`;
+}
+
+export function renderStatusline(_pos: ArtemisPosition): string {
+  // Note: we intentionally ignore most of `_pos`. Artemis II is complete and
+  // there is no live telemetry for an Artemis III ground-processing vehicle.
+  // The statusline is now driven entirely by wall-clock vs ARTEMIS_III_LAUNCH_TARGET.
+  const now = new Date();
+  const countdown = formatCountdown(now);
+  const next = getNextMilestone(now);
+
+  const label = `${C.gold}\uD83D\uDE80 Artemis III${C.reset}`;
+  const tminus = `${C.cyan}${countdown}${C.reset}`;
+  const milestone = `${C.yellow}\u25B8 ${next}${C.reset}`;
+  const a2tag = `${C.dim}\u2713 Artemis II 2026-04-10${C.reset}`;
+
+  return `${label}  ${tminus}  ${milestone}  ${a2tag}`;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,13 @@ export interface ArtemisPosition {
 }
 
 export type MissionPhase =
+  // Pre-launch phases (Artemis III ground processing)
+  | "pre_launch"
+  | "ground_processing"
+  | "rollout"
+  | "wet_dress_rehearsal"
+  | "final_countdown"
+  // In-flight phases (kept for future missions / historical compatibility)
   | "earth_orbit"
   | "transit_to_moon"
   | "lunar_flyby"
@@ -47,5 +54,16 @@ export const API_URL = "https://artemis-api.testa.workers.dev/position";
 export const CACHE_PATH = "/tmp/orion-status-cache.json";
 export const CACHE_TTL_MS = 55_000; // 55s — hold slightly under Horizons' 1min resolution so interpolation runs smooth
 
+// Artemis II launch time (historical — mission completed 2026-04-10).
+// Retained so api.ts and trajectory.ts continue to compile and so we can
+// reference the prior mission for commemoration in the statusline.
 export const LAUNCH_TIME = new Date("2026-04-01T22:35:00Z");
+
+// Artemis III tentative launch target. NASA has NOT announced an exact date
+// as of this commit — the mission was restructured in Feb 2026 to be a LEO/HEO
+// rendezvous + docking demo with commercial HLS landers (no crewed lunar
+// landing; that has slipped to Artemis IV). This placeholder MUST be updated
+// once NASA publishes a confirmed L-0.
+export const ARTEMIS_III_LAUNCH_TARGET = new Date("2027-09-01T00:00:00Z");
+
 export const EARTH_MOON_DISTANCE_KM = 384_400;

--- a/test/statusline.test.ts
+++ b/test/statusline.test.ts
@@ -4,6 +4,9 @@ import assert from "node:assert/strict";
 import { renderStatusline } from "../src/statusline.ts";
 import type { ArtemisPosition } from "../src/types.ts";
 
+// renderStatusline now ignores live telemetry (Artemis II is complete) and is
+// driven by wall-clock vs ARTEMIS_III_LAUNCH_TARGET. The mock only needs to
+// satisfy the ArtemisPosition type.
 const mockPosition: ArtemisPosition = {
   distanceEarthKm: 148302,
   distanceMoonKm: 236098,
@@ -20,27 +23,25 @@ describe("statusline renderer", () => {
     const lines = output.split("\n");
     assert.equal(lines.length, 1);
   });
-  it("includes distance from Earth", () => {
-    const output = renderStatusline(mockPosition);
-    assert.ok(output.includes("148,302"));
-  });
-  it("includes Orion rocket emoji", () => {
+  it("includes the rocket emoji", () => {
     const output = renderStatusline(mockPosition);
     assert.ok(output.includes("🚀"));
   });
-  it("includes mission elapsed time", () => {
+  it("labels the current mission as Artemis III", () => {
     const output = renderStatusline(mockPosition);
-    assert.ok(output.includes("2h 14m"));
+    assert.ok(output.includes("Artemis III"));
   });
-  it("includes trajectory bar with Earth and Moon", () => {
+  it("shows a T-minus or L-plus countdown", () => {
     const output = renderStatusline(mockPosition);
-    assert.ok(output.includes("🌍"));
-    const moonEmojis = ["🌑", "🌒", "🌓", "🌔", "🌕", "🌖", "🌗", "🌘"];
-    assert.ok(moonEmojis.some(e => output.includes(e)));
+    assert.match(output, /T-|L\+/);
   });
-  it("shows stale indicator when data is stale", () => {
-    const stale = { ...mockPosition, stale: true };
-    const output = renderStatusline(stale);
-    assert.ok(output.includes("~"));
+  it("shows the next milestone with a ▸ marker", () => {
+    const output = renderStatusline(mockPosition);
+    assert.ok(output.includes("▸"));
+  });
+  it("keeps an Artemis II completion tag", () => {
+    const output = renderStatusline(mockPosition);
+    assert.ok(output.includes("Artemis II"));
+    assert.ok(output.includes("2026-04-10"));
   });
 });


### PR DESCRIPTION
## Why

Artemis II splashed down **2026-04-10**. The statusline was rendering live distance / velocity / MET / trajectory for a mission that's over, so there's no telemetry left to track. This repoints it at **Artemis III ground processing** with a wall-clock countdown.

## What changed

| File | Change |
|---|---|
| `src/types.ts` | Add pre-launch `MissionPhase` values (`pre_launch`, `ground_processing`, `rollout`, `wet_dress_rehearsal`, `final_countdown`) and `ARTEMIS_III_LAUNCH_TARGET` |
| `src/statusline.ts` | T-minus / L-plus countdown vs the launch target; absolute-time milestone list; drop now-unused `api.ts` / `trajectory.ts` imports |
| `test/statusline.test.ts` | Assert the new contract instead of retired telemetry fields |

New statusline format:
```
🚀 Artemis III  T-451d 5h  ▸ SLS stacking review in 161d  ✓ Artemis II 2026-04-10
```

## Honest caveats

- **`ARTEMIS_III_LAUNCH_TARGET` is a placeholder (2027-09-01).** NASA has **not** announced a hard L-0. Post the Feb-2026 architecture restructure, Artemis III is a LEO/HEO rendezvous + docking demo (no crewed landing — that slipped to Artemis IV). Milestone dates are tentative and flagged as such in code comments. **Update once NASA publishes a confirmed schedule.**
- `renderStatusline` now intentionally ignores most of its `ArtemisPosition` arg; the param is kept for signature/back-compat.

## Verification

- `npm run build` — clean (tsc)
- `npm test` — **14/14 pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Statusline now displays launch countdown in T-/L+ format relative to Artemis III launch target.
  * Added mission milestone tracking and display to statusline.

* **Refactor**
  * Streamlined statusline to focus on countdown and milestones, removing detailed telemetry data for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->